### PR TITLE
Correct OnSuccess WorkFlow

### DIFF
--- a/GoogleCaptcha.Example.Server/Pages/Counter.razor
+++ b/GoogleCaptcha.Example.Server/Pages/Counter.razor
@@ -37,8 +37,8 @@
         base.StateHasChanged();
     }
 
-    private string errorMessage;
-    private string captchaResponse;
+    private string errorMessage = string.Empty;
+    private string captchaResponse = string.Empty;
 
     private int currentCount = 0;
 

--- a/GoogleCaptcha.Exmaple/Pages/Counter.razor
+++ b/GoogleCaptcha.Exmaple/Pages/Counter.razor
@@ -9,14 +9,13 @@
 
 <p>Current count: @currentCount</p>
 
-<GoogleRecaptcha 
-    SuccessCallBack="SuccessCallBack" 
-    TimeOutCallBack="TimeOutCallBack" 
-    ServerValidationErrorCallBack="ServerSideValidationError" 
-    ServerSideValidationHandler="ServerSideValidationHandler"
-    Version="CaptchaConfiguration.Version.V2"
-    Theme="CaptchaConfiguration.Theme.Dark"
-    Language="CaptchaLanguages.EnglishUK">
+<GoogleRecaptcha SuccessCallBack="SuccessCallBack"
+                 TimeOutCallBack="TimeOutCallBack"
+                 ServerValidationErrorCallBack="ServerSideValidationError"
+                 ServerSideValidationHandler="ServerSideValidationHandler"
+                 Version="CaptchaConfiguration.Version.V2"
+                 Theme="CaptchaConfiguration.Theme.Dark"
+                 Language="CaptchaLanguages.EnglishUK">
 </GoogleRecaptcha>
 
 
@@ -24,7 +23,7 @@
 <button class="btn btn-primary" @onclick="ReloadRecapatcha" disabled="@Disabled">reload</button>
 
 @code {
-    
+
     void TimeOutCallBack(CaptchaTimeOutEventArgs e)
     {
         Disabled = true;
@@ -33,11 +32,11 @@
     }
 
 
-     void SuccessCallBack(CaptchaSuccessEventArgs e)
+    void SuccessCallBack(CaptchaSuccessEventArgs e)
     {
         Disabled = false;
 
-         captchaResponse = e.CaptchaResponse;
+        captchaResponse = e.CaptchaResponse;
 
         base.StateHasChanged();
     }
@@ -72,7 +71,7 @@
 
         return new ServerSideCaptchaValidationResultModel(true, "Success");
 
-    // return new ServerSideCaptchaValidationResultModel(apiResult.Success, string.Join("\n",apiResult.ErrorCodes ?? new List<string>(){"No Error"}));
+        // return new ServerSideCaptchaValidationResultModel(apiResult.Success, string.Join("\n",apiResult.ErrorCodes ?? new List<string>(){"No Error"}));
     }
 
     private async Task ReloadRecapatcha()

--- a/GoogleCaptchaComponent/Configuration/CaptchaConfiguration.cs
+++ b/GoogleCaptchaComponent/Configuration/CaptchaConfiguration.cs
@@ -7,7 +7,6 @@ namespace GoogleCaptchaComponent.Configuration;
 /// </summary>
 public class CaptchaConfiguration
 {
-    private bool _serverValidationEnabled;
     /// <summary>
     /// Site key that will be used for V2 Recaptcha. 
     /// </summary>
@@ -42,6 +41,4 @@ public class CaptchaConfiguration
     {
         Dark,Light
     }
-
-    
 }


### PR DESCRIPTION
#17

V4.1.0 ServerSideValidationResult.IsSuccess false =>
1. ServerSideValidationHandler => could set Disabled true
2. ServerValidationErrorCallBack => would set Disabled true
3. SuccessCallBack => would set Disabled false (and IsSuccess isn't available on the EventArg passed in)

This PR fixes the workflow so that OnSuccess only gets called when ServerSideValidationResult.IsSuccess.
